### PR TITLE
Add support for not closeable tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
               <div class="chrome-tab-favicon" style="background-image: url('demo/images/google-favicon.ico')"></div>
               <div class="chrome-tab-title">Google</div>
               <div class="chrome-tab-drag-handle"></div>
-			  <div class="chrome-tab-close"></div>
+              <div class="chrome-tab-close"></div>
             </div>
           </div>
           <div class="chrome-tab" active>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,6 @@
               <div class="chrome-tab-favicon" style="background-image: url('demo/images/google-favicon.ico')"></div>
               <div class="chrome-tab-title">Google</div>
               <div class="chrome-tab-drag-handle"></div>
-              <div class="chrome-tab-close"></div>
             </div>
           </div>
           <div class="chrome-tab" active>
@@ -70,8 +69,10 @@
         <div class="buttons">
           <button data-theme-toggle>Toggle dark theme</button>
           <button data-add-tab>Add new tab</button>
+          <button data-add-not-closeable-tab>Add new not closeable tab</button>
           <button data-add-background-tab>Add tab in the background</button>
           <button data-remove-tab>Remove active tab</button>
+          <button data-remove-all>Remove all tabs</button>
         </div>
       </div>
     </div>
@@ -108,8 +109,24 @@
         })
       })
 
+      document.querySelector('button[data-add-not-closeable-tab]').addEventListener('click', _ => {
+        chromeTabs.addTab({
+          title: 'New Tab',
+          favicon: false
+        }, {
+          closeable: false
+        })
+      })
+
       document.querySelector('button[data-remove-tab]').addEventListener('click', _ => {
         chromeTabs.removeTab(chromeTabs.activeTabEl)
+      })
+      
+
+      document.querySelector('button[data-remove-all]').addEventListener('click', _ => {
+        chromeTabs.tabEls.forEach(element => {
+          chromeTabs.removeTab(element)
+        });
       })
 
       document.querySelector('button[data-theme-toggle]').addEventListener('click', _ => {

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
               <div class="chrome-tab-favicon" style="background-image: url('demo/images/google-favicon.ico')"></div>
               <div class="chrome-tab-title">Google</div>
               <div class="chrome-tab-drag-handle"></div>
+			  <div class="chrome-tab-close"></div>
             </div>
           </div>
           <div class="chrome-tab" active>

--- a/js/chrome-tabs.js
+++ b/js/chrome-tabs.js
@@ -40,7 +40,6 @@
         <div class="chrome-tab-favicon"></div>
         <div class="chrome-tab-title"></div>
         <div class="chrome-tab-drag-handle"></div>
-        <div class="chrome-tab-close"></div>
       </div>
     </div>
   `
@@ -179,14 +178,19 @@
       this.styleEl.innerHTML = styleHTML
     }
 
-    createNewTabEl() {
+    createNewTabEl(closeable) {
       const div = document.createElement('div')
       div.innerHTML = tabTemplate
+      if(closeable){
+        const closeDiv = document.createElement('div')
+        closeDiv.classList.add('chrome-tab-close')
+        div.querySelector('.chrome-tab-content').appendChild(closeDiv)
+      }
       return div.firstElementChild
     }
 
-    addTab(tabProperties, { animate = true, background = false } = {}) {
-      const tabEl = this.createNewTabEl()
+    addTab(tabProperties, { animate = true, background = false, closeable = true } = {}) {
+      const tabEl = this.createNewTabEl(closeable)
 
       if (animate) {
         tabEl.classList.add('chrome-tab-was-just-added')
@@ -202,10 +206,14 @@
       this.cleanUpPreviouslyDraggedTabs()
       this.layoutTabs()
       this.setupDraggabilly()
+      return tabEl
     }
 
     setTabCloseEventListener(tabEl) {
-      tabEl.querySelector('.chrome-tab-close').addEventListener('click', _ => this.removeTab(tabEl))
+      const tab = tabEl.querySelector('.chrome-tab-close')
+      if(tab !== null){
+        tab.addEventListener('click', _ => this.removeTab(tabEl))
+      }
     }
 
     get activeTabEl() {


### PR DESCRIPTION
With these changes, it's possible to have tabs which are not closeable by the user. To make it easier to close them programmatically, the `addTab` function now returns the created element, which can be later used to remove the tab.